### PR TITLE
Small fixes

### DIFF
--- a/color-picker@tuberry/extension.js
+++ b/color-picker@tuberry/extension.js
@@ -187,6 +187,7 @@ const ColorMenu = GObject.registerClass({
         super._init();
         this._color = Clutter.Color.from_string('#ffffff')[1];
         this._menu = new PopupMenu.PopupMenu(actor, 0.25, St.Side.LEFT);
+        this._menu.connect('open-state-changed', (menu, open) => global.display.set_cursor(Meta.Cursor[open ? 'DEFAULT' : 'CROSSHAIR']));
         this.actor.style_class = 'color-picker-menu popup-menu';
         this._menuManager = new PopupMenu.PopupMenuManager(area);
         this._menuManager.addMenu(this._menu);

--- a/color-picker@tuberry/extension.js
+++ b/color-picker@tuberry/extension.js
@@ -324,7 +324,7 @@ const ColorMenu = GObject.registerClass({
     }
 
     destroy() {
-        this.actor.destroy();
+        this._menu.destroy();
         this._menu = null;
         this._menuManager = null;
     }
@@ -421,10 +421,10 @@ const ColorArea = GObject.registerClass({
         if(this._onMenuColorSelectedId) this._menu.disconnect(this._onMenuColorSelectedId), this._onMenuColorSelectedId = 0;
         Main.layoutManager.removeChrome(this._menu.actor);
         Main.layoutManager.removeChrome(this._icon);
-        this._icon.destroy();
         this._menu.destroy();
-        this._icon = null;
+        this._icon.destroy();
         this._menu = null;
+        this._icon = null;
     }
 
     _onKeyPressed(actor, event) {
@@ -496,6 +496,8 @@ const ColorArea = GObject.registerClass({
         this._pick = null;
         this._pointer = null;
         this._enablePreview = false;
+
+        super.destroy();
     }
 });
 

--- a/color-picker@tuberry/extension.js
+++ b/color-picker@tuberry/extension.js
@@ -188,7 +188,7 @@ const ColorMenu = GObject.registerClass({
         this._color = Clutter.Color.from_string('#ffffff')[1];
         this._menu = new PopupMenu.PopupMenu(actor, 0.25, St.Side.LEFT);
         this._menu.connect('open-state-changed', (menu, open) => global.display.set_cursor(Meta.Cursor[open ? 'DEFAULT' : 'CROSSHAIR']));
-        this.actor.style_class = 'color-picker-menu popup-menu';
+        this.actor.add_style_class_name('color-picker-menu');
         this._menuManager = new PopupMenu.PopupMenuManager(area);
         this._menuManager.addMenu(this._menu);
     }

--- a/color-picker@tuberry/extension.js
+++ b/color-picker@tuberry/extension.js
@@ -366,10 +366,7 @@ const ColorArea = GObject.registerClass({
         this._pick = new Shell.Screenshot();
         this._pointer = Clutter.get_default_backend().get_default_seat().create_virtual_device(Clutter.InputDeviceType.POINTER_DEVICE);
         this._enablePreview = gsettings.get_boolean(Fields.ENABLEPREVIEW);
-
         this._enablePreviewId = gsettings.connect(`changed::${Fields.ENABLEPREVIEW}`, () => { this._enablePreview = gsettings.get_boolean(Fields.ENABLEPREVIEW); });
-        this._onKeyPressedId = this.connect('key-press-event', this._onKeyPressed.bind(this));
-        this._onButtonPressedId = this.connect('button-press-event', this._onButtonPressed.bind(this));
     }
 
     get _enablePreview() {
@@ -419,17 +416,15 @@ const ColorArea = GObject.registerClass({
 
     _removePreviewCursor() {
         if(this._onMenuColorSelectedId) this._menu.disconnect(this._onMenuColorSelectedId), this._onMenuColorSelectedId = 0;
-        Main.layoutManager.removeChrome(this._menu.actor);
-        Main.layoutManager.removeChrome(this._icon);
         this._menu.destroy();
         this._icon.destroy();
         this._menu = null;
         this._icon = null;
     }
 
-    _onKeyPressed(actor, event) {
+    vfunc_key_press_event(event) {
         let [X, Y] = global.get_pointer();
-        switch(event.get_key_symbol()) {
+        switch(event.keyval) {
         case Clutter.KEY_Left:
             this._pointer.notify_absolute_motion(global.get_current_time(), X-1, Y);
             break;
@@ -454,8 +449,8 @@ const ColorArea = GObject.registerClass({
         }
     }
 
-    _onButtonPressed(actor, event) {
-        switch(event.get_button()) {
+    vfunc_button_press_event(event) {
+        switch(event.button) {
         case 1:
             if(this._enablePreview) {
                 let hex = convColorToCSS(this._effect.color, NOTATION.HEX);
@@ -490,8 +485,6 @@ const ColorArea = GObject.registerClass({
 
     destroy() {
         if(this._enablePreviewId) gsettings.disconnect(this._enablePreviewId), this._enablePreviewId = 0;
-        if(this._onKeyPressedId)    this.disconnect(this._onKeyPressedId), this._onKeyPressedId = 0;
-        if(this._onButtonPressedId) this.disconnect(this._onButtonPressedId), this._onButtonPressedId = 0;
 
         this._pick = null;
         this._pointer = null;
@@ -661,7 +654,6 @@ class ColorPicker extends GObject.Object {
         if(this._area.showId) this._area.disconnect(this._area.showId), this._area.showId = 0;
         if(this._area.showMenuId) this._area.disconnect(this._area.showMenuId), this._area.showMenuId = 0;
         if(Main._findModal(this._area) != -1) Main.popModal(this._area);
-        Main.layoutManager.removeChrome(this._area);
         this._area.destroy();
         this._area = null;
     }

--- a/color-picker@tuberry/extension.js
+++ b/color-picker@tuberry/extension.js
@@ -445,6 +445,9 @@ const ColorArea = GObject.registerClass({
         case Clutter.KEY_Escape:
             this.emit('end-pick');
             break;
+        case Clutter.KEY_Menu:
+            if(this._enablePreview) this._menu.open(this._effect.color);
+            break;
         default:
             if(!this._persistentMode) this.emit('end-pick');
             break;

--- a/color-picker@tuberry/extension.js
+++ b/color-picker@tuberry/extension.js
@@ -713,7 +713,6 @@ class ColorPicker extends GObject.Object {
                     resolve(color);
                 });
                 this._area.showMenuId = this._area.connect('notify-menu-color', (actor, color) => {
-                    this._endPick();
                     resolve(color);
                 });
                 Main.pushModal(this._area, { actionMode: Shell.ActionMode.NORMAL });


### PR DESCRIPTION
The last commit is completely optional. It can be removed.

retrieve the default cursor when the menu is open:
* Fixes #7.

menu background:
* Keep the popup-menu-boxpointer style class so the background is not transparent.

menu key:
* Open the menu on 'Menu' key pressed. Fixes #8.

do not end picking twice:
* Since a388bde, the color area handles picking ending when a color is selected from the menu.

destroy:
* Call Clutter.Actor.prototype.destroy (`super.destroy`) to really destroy the area.
* Use PopupMenu.prototype.destroy to destroy the menu actor. It must be called before destroying `area._icon`, which is its source actor.

clean:
* `removeChrome` is useless because the layout manager takes care of untracking destroyed actors.
* Do not bother with signal handlers and use virtual functions.