### PR TITLE
Systray Icon Padding

### DIFF
--- a/color-picker@tuberry/extension.js
+++ b/color-picker@tuberry/extension.js
@@ -605,7 +605,10 @@ class ColorButton extends PanelMenu.Button {
     _buildWidgets() {
         this.menu.actor.add_style_class_name('app-menu');
         this.add_style_class_name('color-picker-systray');
-        this._icon = new St.Icon({ style_class: 'system-status-icon' });
+        this._icon = new St.Icon({
+            style_class: 'system-status-icon',
+            style: "padding-left: 0px; padding-right: 0px;"
+        });
         this.add_actor(this._icon);
     }
 

--- a/color-picker@tuberry/metadata.json
+++ b/color-picker@tuberry/metadata.json
@@ -8,5 +8,5 @@
     "43"
   ],
   "url": "https://github.com/tuberry/color-picker",
-  "version": 1
+  "version": 35
 }


### PR DESCRIPTION
Hello,

Great extension! Minor gried but as gnome 40+ is quite liberal with icon padding, would it be possible to reduce the icon padding from (see elongated gray icon area)
![image](https://user-images.githubusercontent.com/56710655/208298944-64d4d3ce-9171-493e-9e95-14f5f93fdaa6.png)
to (see round icon area)
![image](https://user-images.githubusercontent.com/56710655/208298812-eb191254-f49e-4a1c-a05a-697894024a11.png)
in order to reduce the space used by the icon and for consistency with other extensions:
![image](https://user-images.githubusercontent.com/56710655/208298984-15cd0d12-db43-471f-993d-d2257005fa1e.png)

I'm also not sure why the version on github is version 1 so I updated that as otherwise, the extension updates itself automatically which is quite frustrating...