### PR TITLE
chore(meson.build): bump version to 48.0

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,7 +1,7 @@
 project(
   'gnome-shell-extension-color-picker',
   license: 'GPL-3.0-or-later',
-  version: '47.beta',
+  version: '48.0',
 )
 
 _name = meson.project_name().replace('gnome-shell-extension-', '')


### PR DESCRIPTION
Enables compatibility with GNOME shell 48.0.

Tested on CachyOS (Arch-based), kernel 6.13.7, GNOME shell 48.0.